### PR TITLE
Mener disse schemaene bør være like og ha srs.

### DIFF
--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigforbud.sjekk.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigforbud.sjekk.schema.json
@@ -5,36 +5,59 @@
     "definitions": {},
     "type": "object",
     "properties": {
-        "omraade": {
+      "crs": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object",
             "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "Polygon"
-                    ]
-                },
-                "coordinates": {
-                    "type": "array",
-                    "items": {
-                        "type": "array",
-                        "minItems": 4,
-                        "items": {
-                            "type": "array",
-                            "minItems": 2,
-                            "items": {
-                                "type": "number"
-                            }
-                        }
-                    }
-                }
+              "name": {
+                "type": "string"
+              }
             },
             "required": [
-                "type",
-                "coordinates"
+              "name"
             ]
-        }
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "omraade": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Polygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "minItems": 4,            
+              "items": {
+                "type": "array",
+                "minItems": 2,
+                "items": {
+                  "type": "number"
+                }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "coordinates"
+        ]
+      }
     },
     "required": [
-        "omraade"
+      "omraade",
+      "crs"
     ]
-}
+  }
+  

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforomraade.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforomraade.finn.schema.json
@@ -2,40 +2,62 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnPlanerForOmraade.v2.schema.json",
     "title": "FinnPlanerForOmraade",
-    "definitions": {
-        "linearRing": {
-            "description": "An array of four positions where the first equals the last",
-            "allOf": [
-                { "$ref": "#/definitions/positionArray" },
-                { "minItems": 4 }
-            ]
-        },
-        "positionArray": {
-            "description": "An array of positions",
-            "type": "array",
-            "items": { "$ref": "#/definitions/position" }
-        },
-        "position": {
-            "description": "A single position",
-            "type": "array",
-            "minItems": 2,
-            "items": [
-                { "type": "number" },
-                { "type": "number" }
-            ],
-            "additionalItems": false
-        }
-    },
+    "definitions": {},
     "type": "object",
     "properties": {
-        "omraade": {
-            "type": "array",
-            "allOf": [
-                { "$ref": "#/definitions/linearRing" }
+      "crs": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "properties": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name"
             ]
-        }
+          }
+        },
+        "required": [
+          "type",
+          "properties"
+        ]
+      },
+      "omraade": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "Polygon"
+            ]
+          },
+          "coordinates": {
+            "type": "array",
+            "minItems": 4,
+            "items": {
+              "type": "array",
+              "minItems": 2,
+              "items": {
+                "type": "number"
+              }
+            }
+          }
+        },
+        "required": [
+          "type",
+          "coordinates"
+        ]
+      }
     },
     "required": [
-        "omraade"
+      "omraade",
+      "crs"
     ]
-}
+  }
+  


### PR DESCRIPTION
Skriver et innlegg på slack for pullrequesten.
Testdata til endringsforslaget:
{
  "omraade": {
    "coordinates": [
      [
        5.747700000038293,
        58.96795200725495
      ],
      [
        5.747700000038293,
        58.96064512489946
      ],
      [
        5.756748518238851,
        58.96064512489946
      ],
      [
        5.756748518238851,
        58.96795200725495
      ],
      [
        5.747700000038293,
        58.96795200725495
      ]
    ],
    "type": "Polygon"
  },
  "crs": {
    "type": "name",
    "properties": {
      "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
    }
  }
}