### PR TITLE
Justeringer på schemas

### DIFF
--- a/Schema/V2/no.ks.fiks.plan.v2.feilmelding.ikkefunnet.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.feilmelding.ikkefunnet.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.kvittering/ikkefunnet.v1.schema.json",
+  "$id": "no.ks.fiks.plan.v2.feilmelding.ikkefunnet.schema.json",
   "title": "ikkefunnet",
   "definitions": {
   },

--- a/Schema/V2/no.ks.fiks.plan.v2.feilmelding.serverfeil.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.feilmelding.serverfeil.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.kvittering/serverfeil.v1.schema.json",
+  "$id": "no.ks.fiks.plan.v2.feilmelding.serverfeil.schema.json",
   "title": "serverfeil",
   "definitions": {},
   "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.feilmelding.ugyldigforespoersel.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.feilmelding.ugyldigforespoersel.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://no.ks.fiks.kvittering/ugyldigforespoersel.v1.schema.json",
+  "$id": "no.ks.fiks.plan.v2.feilmelding.ugyldigforespoersel.schema.json",
   "title": "ugyldigforespoersel",
   "definitions": {
   },

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json
@@ -1,0 +1,49 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json",
+    "title": "NasjonalArealplanId",
+    "definitions": {},
+    "type": "object",
+    "properties": {
+        "administrativEnhet": {
+            "properties": {
+                "kommunenummer": {
+                    "description": "Kommunenummer",
+                    "type": "string"
+                },
+                "fylkesnummer": {
+                    "description": "Fylkesnummer",
+                    "type": "string"
+                },
+                "landskode": {
+                    "description": "Landskode",
+                    "type": "string"
+                }
+            },
+            "oneOf": [
+                {
+                    "required": [
+                        "kommunenummer"
+                    ]
+                },
+                {
+                    "required": [
+                        "fylkesnummer"
+                    ]
+                },
+                {
+                    "required": [
+                        "landskode"
+                    ]
+                }
+            ]
+        },
+        "planidentifikasjon": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "administrativEnhet",
+        "planidentifikasjon"
+    ]
+}

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.hent.schema.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentAktoerer.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.aktoerer.hent.schema.json",
     "title": "HentAktoerer",
     "definitions": {},
     "type": "object",
@@ -21,37 +21,7 @@
             ]
         },
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         }
     }
 }

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.aktoerer.resultat.schema.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/Aktorer.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.aktoerer.resultat.schema.json",
     "title": "Aktoerer",
     "definitions": {},
     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.arealplan.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.arealplan.hent.schema.json
@@ -1,43 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentArealplan.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.arealplan.hent.schema.json",
     "title": "HentArealplan",
     "definitions": {
     },
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
         "returnerPlanbehandlinger": {
             "type": "boolean"

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.arealplan.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.arealplan.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentArealplan.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.arealplan.resultat.schema.json",
     "title": "HentArealplan",
     "definitions": {
         "Planbehandling": {
@@ -96,37 +96,7 @@
             "type": "object",
             "properties": {
                 "nasjonalArealplanId": {
-                    "type": "object",
-                    "properties": {
-                        "administrativEnhet": {
-                            "properties": {
-                                "kommunenummer": {
-                                    "description": "Kommunenummer",
-                                    "type": "string"
-                                },
-                                "fylkesnummer": {
-                                    "description": "Fylkesnummer",
-                                    "type": "string"
-                                },
-                                "landskode": {
-                                    "description": "Landskode",
-                                    "type": "string"
-                                }
-                            },
-                            "oneOf": [
-                                { "required": [ "kommunenummer" ] },
-                                { "required": [ "fylkesnummer" ] },
-                                { "required": [ "landskode" ] }
-                            ]
-                        },
-                        "planidentifikasjon": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "administrativEnhet",
-                        "planidentifikasjon"
-                    ]
+                    "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
                 },
                 "plantype": {
                     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.bboxforplan.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.bboxforplan.hent.schema.json
@@ -1,43 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentBboxForPlan.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.bboxforplan.hent.schema.json",
     "title": "HentBboxForPlan",
     "definitions": {
     },
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
         "koordinatsystem": {
             "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.bboxforplan.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.bboxforplan.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/Bbox.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.bboxforplan.resultat.schema.json",
     "title": "Bbox",
     "definitions": {
     },

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.dispensasjoner.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.dispensasjoner.finn.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnDispensasjoner.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.dispensasjoner.finn.schema.json",
     "title": "FinnDispensasjoner",
     "definitions": {
     },

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.dispensasjoner.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.dispensasjoner.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/Dispensasjoner.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.dispensasjoner.resultat.schema.json",
     "title": "Dispensasjoner",
     "definitions": {
         "dispensasjon": {
@@ -19,37 +19,7 @@
                 }
             },
             "nasjonalArealplanId": {
-                "type": "object",
-                "properties": {
-                    "administrativEnhet": {
-                        "properties": {
-                            "kommunenummer": {
-                                "description": "Kommunenummer",
-                                "type": "string"
-                            },
-                            "fylkesnummer": {
-                                "description": "Fylkesnummer",
-                                "type": "string"
-                            },
-                            "landskode": {
-                                "description": "Landskode",
-                                "type": "string"
-                            }
-                        },
-                        "oneOf": [
-                            { "required": [ "kommunenummer" ] },
-                            { "required": [ "fylkesnummer" ] },
-                            { "required": [ "landskode" ] }
-                        ]
-                    },
-                    "planidentifikasjon": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "administrativEnhet",
-                    "planidentifikasjon"
-                ]
+                "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
             },
             "begrunnelse": {
                 "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.gjeldendeplanbestemmelser.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.gjeldendeplanbestemmelser.hent.schema.json
@@ -1,43 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentGjeldendePlanbestemmelser.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.gjeldendeplanbestemmelser.hent.schema.json",
     "title": "HentGjeldendePlanbestemmelser",
     "definitions": {
     },
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         }
     },
     "required": [

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.gjeldendeplanbestemmelser.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.gjeldendeplanbestemmelser.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/GjeldendePlanbestemmelser.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.gjeldendeplanbestemmelser.resultat.schema.json",
     "title": "GjeldendePlanbestemmelser",
     "definitions": {
         "Plandokument": {

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.kodeliste.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.kodeliste.hent.schema.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentKodeliste.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.kodeliste.hent.schema.json",
     "title": "HentKodeliste",
     "definitions": {},
     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.kodeliste.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.kodeliste.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/Kodeliste.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.kodeliste.resultat.schema.json",
     "title": "Kodeliste",
     "definitions": {},
     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigforbud.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigforbud.resultat.schema.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/MidlertidigForbud.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.midlertidigforbud.resultat.schema.json",
     "title": "MidlertidigForbud",
     "definitions": {},
     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigforbud.sjekk.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigforbud.sjekk.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/SjekkMidlertidigForbud.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.midlertidigforbud.sjekk.schema.json",
     "title": "SjekkMidlertidigForbud",
     "definitions": {},
     "type": "object",
@@ -28,36 +28,36 @@
           "properties"
         ]
       },
-      "omraade": {
+        "omraade": {
         "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-              "Polygon"
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "Polygon"
+                    ]
+                },
+                "coordinates": {
+                    "type": "array",
+                        "minItems": 4,
+                        "items": {
+                            "type": "array",
+                            "minItems": 2,
+                            "items": {
+                                "type": "number"
+                            }
+                        }
+                    }
+            },
+            "required": [
+                "type",
+                "coordinates"
             ]
-          },
-          "coordinates": {
-            "type": "array",
-            "minItems": 4,            
-              "items": {
-                "type": "array",
-                "minItems": 2,
-                "items": {
-                  "type": "number"
-                }
-            }
-          }
-        },
-        "required": [
-          "type",
-          "coordinates"
-        ]
-      }
+        }
     },
     "required": [
       "omraade",
       "crs"
     ]
-  }
+}
   

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planbehandlinger.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planbehandlinger.finn.schema.json
@@ -1,42 +1,12 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnPlanbehandlinger.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planbehandlinger.finn.schema.json",
     "title": "FinnPlanbehandlinger",
     "definitions": {},
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         }
     },
     "required": [ "nasjonalArealplanId" ]

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planbehandlinger.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planbehandlinger.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/Planbehandlinger.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planbehandlinger.resultat.schema.json",
     "title": "Planbehandlinger",
     "definitions": {
         "Planbehandling": {

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.plandokumenter.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.plandokumenter.finn.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnPlandokumenter.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.plandokumenter.finn.schema.json",
     "title": "FinnPlandokumenter",
     "definitions": {
     },

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.plandokumenter.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.plandokumenter.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/Plandokumenter.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.plandokumenter.resultat.schema.json",
     "title": "Plandokumenter",
     "definitions": {
         "Plandokument": {

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planer.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planer.finn.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnPlaner.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planer.finn.schema.json",
     "title": "FinnPlaner",
     "definitions": {
     },

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planer.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planer.resultat.schema.json
@@ -1,43 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/PlanerForSoek.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planer.resultat.schema.json",
     "title": "PlanerForSoek",
     "definitions": {
         "plan": {
             "type": "object",
             "properties": {
                 "nasjonalArealplanId": {
-                    "type": "object",
-                    "properties": {
-                        "administrativEnhet": {
-                            "properties": {
-                                "kommunenummer": {
-                                    "description": "Kommunenummer",
-                                    "type": "string"
-                                },
-                                "fylkesnummer": {
-                                    "description": "Fylkesnummer",
-                                    "type": "string"
-                                },
-                                "landskode": {
-                                    "description": "Landskode",
-                                    "type": "string"
-                                }
-                            },
-                            "oneOf": [
-                                { "required": [ "kommunenummer" ] },
-                                { "required": [ "fylkesnummer" ] },
-                                { "required": [ "landskode" ] }
-                            ]
-                        },
-                        "planidentifikasjon": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "administrativEnhet",
-                        "planidentifikasjon"
-                    ]
+                    "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
                 },
                 "plantype": {
                     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforadresse.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforadresse.finn.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnPlanerForAdresse.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planerforadresse.finn.schema.json",
     "title": "FinnPlanerForAdresse",
     "description": "Finner alle planer som beroerer en adresse. ",
     "definitions": {

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforadresse.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforadresse.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/PlanerForAdresse.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planerforadresse.resultat.schema.json",
     "title": "PlanerForAdresse",
     "description": "Resultat for alle planer som beroerer en adresse. ",
     "definitions": {
@@ -8,37 +8,7 @@
             "type": "object",
             "properties": {
                 "nasjonalArealplanId": {
-                    "type": "object",
-                    "properties": {
-                        "administrativEnhet": {
-                            "properties": {
-                                "kommunenummer": {
-                                    "description": "Kommunenummer",
-                                    "type": "string"
-                                },
-                                "fylkesnummer": {
-                                    "description": "Fylkesnummer",
-                                    "type": "string"
-                                },
-                                "landskode": {
-                                    "description": "Landskode",
-                                    "type": "string"
-                                }
-                            },
-                            "oneOf": [
-                                { "required": [ "kommunenummer" ] },
-                                { "required": [ "fylkesnummer" ] },
-                                { "required": [ "landskode" ] }
-                            ]
-                        },
-                        "planidentifikasjon": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "administrativEnhet",
-                        "planidentifikasjon"
-                    ]
+                    "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
                 },
                 "plantype": {
                     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerformatrikkelenhet.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerformatrikkelenhet.finn.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnPlanerForMatrikkelenhet.v2.schema.json",
+  "$id": "no.ks.fiks.plan.v2.innsyn.planerformatrikkelenhet.finn.schema.json",
   "title": "FinnPlanerForMatrikkelenhet",
   "description": "Finner alle planer som beroerer en eiendom. ",
   "definitions": {

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerformatrikkelenhet.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerformatrikkelenhet.resultat.schema.json
@@ -1,84 +1,54 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://no.ks.fiks.gi.plan.innsyn/PlanerForMatrikkelenhet.v2.schema.json",
+  "$id": "no.ks.fiks.plan.v2.innsyn.planerformatrikkelenhet.resultat.schema.json",
   "title": "PlanerForMatrikkelenhet",
   "description": "Finner alle planer som beroerer en eiendom. ",
   "definitions": {
     "Arealplan": {
       "type": "object",
-        "properties": {
-            "nasjonalArealplanId": {
-                "type": "object",
-                "properties": {
-                    "administrativEnhet": {
-                        "properties": {
-                            "kommunenummer": {
-                                "description": "Kommunenummer",
-                                "type": "string"
-                            },
-                            "fylkesnummer": {
-                                "description": "Fylkesnummer",
-                                "type": "string"
-                            },
-                            "landskode": {
-                                "description": "Landskode",
-                                "type": "string"
-                            }
-                        },
-                        "oneOf": [
-                            { "required": [ "kommunenummer" ] },
-                            { "required": [ "fylkesnummer" ] },
-                            { "required": [ "landskode" ] }
-                        ]
-                    },
-                    "planidentifikasjon": {
-                        "type": "string"
-                    }
-                },
-                "required": [
-                    "administrativEnhet",
-                    "planidentifikasjon"
-                ]
-            },
-            "plantype": {
-                "type": "object",
-                "properties": {
-                    "kodeverdi": {
-                        "type": "string"
-                    },
-                    "kodebeskrivelse": {
-                        "type": "string"
-                    }
-                }
-            },
-            "plannavn": {
-                "type": "string"
-            },
-            "planstatus": {
-                "type": "object",
-                "properties": {
-                    "kodeverdi": {
-                        "type": "string"
-                    },
-                    "kodebeskrivelse": {
-                        "type": "string"
-                    }
-                }
-            },
-            "plandokumentasjonOppdatert": {
-                "type": "boolean"
-            },
-            "ubehandletKlage": {
-                "type": "boolean"
-            },
-            "ubehandletInnsigelse": {
-                "type": "boolean"
-            },
-            "vedtaksdato": {
-                "type": "string",
-                "format": "date"
-            }
+      "properties": {
+        "nasjonalArealplanId": {
+          "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
+        "plantype": {
+          "type": "object",
+          "properties": {
+            "kodeverdi": {
+              "type": "string"
+            },
+            "kodebeskrivelse": {
+              "type": "string"
+            }
+          }
+        },
+        "plannavn": {
+          "type": "string"
+        },
+        "planstatus": {
+          "type": "object",
+          "properties": {
+            "kodeverdi": {
+              "type": "string"
+            },
+            "kodebeskrivelse": {
+              "type": "string"
+            }
+          }
+        },
+        "plandokumentasjonOppdatert": {
+          "type": "boolean"
+        },
+        "ubehandletKlage": {
+          "type": "boolean"
+        },
+        "ubehandletInnsigelse": {
+          "type": "boolean"
+        },
+        "vedtaksdato": {
+          "type": "string",
+          "format": "date"
+        }
+      },
       "required": [
         "nasjonalArealplanId",
         "plantype",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforomraade.finn.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforomraade.finn.schema.json
@@ -1,13 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/FinnPlanerForOmraade.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planerforomraade.finn.schema.json",
     "title": "FinnPlanerForOmraade",
     "definitions": {},
     "type": "object",
     "properties": {
       "crs": {
-        "type": "object",
-        "properties": {
+    "type": "object",
+    "properties": {
           "type": {
             "type": "string"
           },
@@ -28,7 +28,7 @@
           "properties"
         ]
       },
-      "omraade": {
+        "omraade": {
         "type": "object",
         "properties": {
           "type": {
@@ -47,9 +47,9 @@
                 "type": "number"
               }
             }
-          }
-        },
-        "required": [
+        }
+    },
+    "required": [
           "type",
           "coordinates"
         ]
@@ -59,5 +59,5 @@
       "omraade",
       "crs"
     ]
-  }
+}
   

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforomraade.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planerforomraade.resultat.schema.json
@@ -1,43 +1,13 @@
 ﻿{
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/PlanerForOmraade.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planerforomraade.resultat.schema.json",
     "title": "PlanerForOmraade",
     "definitions": {
         "Arealplan": {
             "type": "object",
             "properties": {
                 "nasjonalArealplanId": {
-                    "type": "object",
-                    "properties": {
-                        "administrativEnhet": {
-                            "properties": {
-                                "kommunenummer": {
-                                    "description": "Kommunenummer",
-                                    "type": "string"
-                                },
-                                "fylkesnummer": {
-                                    "description": "Fylkesnummer",
-                                    "type": "string"
-                                },
-                                "landskode": {
-                                    "description": "Landskode",
-                                    "type": "string"
-                                }
-                            },
-                            "oneOf": [
-                                { "required": [ "kommunenummer" ] },
-                                { "required": [ "fylkesnummer" ] },
-                                { "required": [ "landskode" ] }
-                            ]
-                        },
-                        "planidentifikasjon": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "administrativEnhet",
-                        "planidentifikasjon"
-                    ]
+                    "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
                 },
                 "plantype": {
                     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planfil.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planfil.hent.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentPlanfil.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planfil.hent.schema.json",
     "title": "HentPlanfil",
     "definitions": {},
     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planomraader.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planomraader.hent.schema.json
@@ -1,42 +1,12 @@
 ﻿{
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentPlanomraader.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planomraader.hent.schema.json",
     "title": "HentPlanomraader",
     "definitions": {},
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
         "koordinatsystem": {
             "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.planomraader.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.planomraader.resultat.schema.json
@@ -1,6 +1,6 @@
 ﻿{
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/Planomraader.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.planomraader.resultat.schema.json",
     "title": "Planomraader",
     "definitions": {},
     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.relaterteplaner.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.relaterteplaner.hent.schema.json
@@ -1,42 +1,12 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/HentRelatertePlaner.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.relaterteplaner.hent.schema.json",
     "title": "HentRelatertePlaner",
     "definitions": {},
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         }
     },
     "required": [

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.relaterteplaner.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.relaterteplaner.resultat.schema.json
@@ -1,42 +1,12 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.innsyn/RelatertePlaner.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.innsyn.relaterteplaner.resultat.schema.json",
     "title": "RelatertePlaner",
     "definitions": {},
     "type": "object",
     "properties": {
       "nasjonalArealplanId": {
-        "type": "object",
-        "properties": {
-          "administrativEnhet": {
-            "properties": {
-              "kommunenummer": {
-                "description": "Kommunenummer",
-                "type": "string"
-              },
-              "fylkesnummer": {
-                "description": "Fylkesnummer",
-                "type": "string"
-              },
-              "landskode": {
-                "description": "Landskode",
-                "type": "string"
-              }
-            },
-            "oneOf": [
-              { "required": [ "kommunenummer" ] },
-              { "required": [ "fylkesnummer" ] },
-              { "required": [ "landskode" ] }
-            ]
-          },
-          "planidentifikasjon": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "administrativEnhet",
-          "planidentifikasjon"
-        ]
+        "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
       },
       "planrelasjon": {
         "type": "array",
@@ -61,37 +31,7 @@
               "type": "object",
               "properties": {
                 "nasjonalArealplanId": {
-                  "type": "object",
-                  "properties": {
-                    "administrativEnhet": {
-                      "properties": {
-                        "kommunenummer": {
-                          "description": "Kommunenummer",
-                          "type": "string"
-                        },
-                        "fylkesnummer": {
-                          "description": "Fylkesnummer",
-                          "type": "string"
-                        },
-                        "landskode": {
-                          "description": "Landskode",
-                          "type": "string"
-                        }
-                      },
-                      "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                      ]
-                    },
-                    "planidentifikasjon": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "administrativEnhet",
-                    "planidentifikasjon"
-                  ]
+                  "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
                 },
                 "plantype": {
                   "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/OppdaterArealplan.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json",
     "title": "OppdaterArealplan",
     "definitions": {
         "Plandokument": {

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
@@ -42,39 +42,8 @@
     },
     "type": "object",
     "properties": {
-        "arealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "type": "object",
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "kommunenummer",
-                        "fylkesnummer",
-                        "landskode"
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+        "nasjonalArealplanId": {
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
         "plannavn": {
             "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.opprett.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.opprett.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/OpprettArealplan.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.arealplan.opprett.schema.json",
     "title": "OpprettArealplan",
     "definitions": {},
     "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjon.oppdater.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjon.oppdater.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/OppdaterDispensasjon.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.dispensasjon.oppdater.schema.json",
     "title": "OppdaterDispensasjon",
     "definitions": {
         "Plandokument": {
@@ -61,37 +61,7 @@
                     }
                 },
                 "nasjonalArealplanId": {
-                    "type": "object",
-                    "properties": {
-                        "administrativEnhet": {
-                            "properties": {
-                                "kommunenummer": {
-                                    "description": "Kommunenummer",
-                                    "type": "string"
-                                },
-                                "fylkesnummer": {
-                                    "description": "Fylkesnummer",
-                                    "type": "string"
-                                },
-                                "landskode": {
-                                    "description": "Landskode",
-                                    "type": "string"
-                                }
-                            },
-                            "oneOf": [
-                                { "required": [ "kommunenummer" ] },
-                                { "required": [ "fylkesnummer" ] },
-                                { "required": [ "landskode" ] }
-                            ]
-                        },
-                        "planidentifikasjon": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "administrativEnhet",
-                        "planidentifikasjon"
-                    ]
+                    "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
                 },
                 "begrunnelse": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjonplan.registrer.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjonplan.registrer.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/RegistrerDispensasjonPlan.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.dispensasjonplan.registrer.schema.json",
     "title": "RegistrerDispensasjonPlan",
     "definitions": {
         "Plandokument": {
@@ -61,37 +61,7 @@
                     }
                 },
                 "nasjonalArealplanId": {
-                    "type": "object",
-                    "properties": {
-                        "administrativEnhet": {
-                            "properties": {
-                                "kommunenummer": {
-                                    "description": "Kommunenummer",
-                                    "type": "string"
-                                },
-                                "fylkesnummer": {
-                                    "description": "Fylkesnummer",
-                                    "type": "string"
-                                },
-                                "landskode": {
-                                    "description": "Landskode",
-                                    "type": "string"
-                                }
-                            },
-                            "oneOf": [
-                                { "required": [ "kommunenummer" ] },
-                                { "required": [ "fylkesnummer" ] },
-                                { "required": [ "landskode" ] }
-                            ]
-                        },
-                        "planidentifikasjon": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "administrativEnhet",
-                        "planidentifikasjon"
-                    ]
+                    "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
                 },
                 "begrunnelse": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjonplan.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.dispensasjonplan.resultat.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/RegistrerDispensasjonResultat.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.dispensasjonplan.resultat.schema.json",
     "title": "RegistrerDispensasjonResultat",
     "type": "object",
     "properties": {

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.meldingomplanident.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.meldingomplanident.resultat.schema.json
@@ -1,43 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/MeldingOmPlanident.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.meldingomplanident.resultat.schema.json",
     "title": "MeldingOmPlanident",
     "definitions": {
     },
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
         "saksnummer": {
             "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.midlertidigforbudmottiltak.registrer.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.midlertidigforbudmottiltak.registrer.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/RegistrerMidlertidigForbudMotTiltak.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.midlertidigforbudmottiltak.registrer.schema.json",
     "description": "Forvaltning av «midlertidig forbud mot tiltak» i planregister ”Midlertidig forbud mot tiltak” er ikke en plantype, og dermed heller ikke arealplandata, men gyldighetsområdet skal likevel inngå i kommunalt planregister, og forvaltes som et eget datalag. Dette fordi slike midlertidige forbud mot tiltak utgjør en kraftig restriksjon i videre bruk av arealer inntil det er gjennomført ny planprosess. ",
     "title": "RegistrerMidlertidigForbudMotTiltak",
     "definitions": {},

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planavgrensning.registrer.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planavgrensning.registrer.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/RegistrerPlanavgrensning.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.planavgrensning.registrer.schema.json",
     "title": "RegistrerPlanavgrensning",
     "definitions": {
         "Plandokument": {
@@ -44,37 +44,7 @@
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
         "saksnummer": {
             "type": "object",

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planbehandling.registrer.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planbehandling.registrer.schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://no.ks.fiks.gi.plan.oppdatering/RegistrerPlanbehandling.v2.schema.json",
+    "$id": "no.ks.fiks.plan.v2.oppdatering.planbehandling.registrer.schema.json",
     "title": "RegistrerPlanbehandling",
     "definitions": {
         "Plandokument": {
@@ -44,37 +44,7 @@
     "type": "object",
     "properties": {
         "nasjonalArealplanId": {
-            "type": "object",
-            "properties": {
-                "administrativEnhet": {
-                    "properties": {
-                        "kommunenummer": {
-                            "description": "Kommunenummer",
-                            "type": "string"
-                        },
-                        "fylkesnummer": {
-                            "description": "Fylkesnummer",
-                            "type": "string"
-                        },
-                        "landskode": {
-                            "description": "Landskode",
-                            "type": "string"
-                        }
-                    },
-                    "oneOf": [
-                        { "required": [ "kommunenummer" ] },
-                        { "required": [ "fylkesnummer" ] },
-                        { "required": [ "landskode" ] }
-                    ]
-                },
-                "planidentifikasjon": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "administrativEnhet",
-                "planidentifikasjon"
-            ]
+            "$ref": "no.ks.fiks.plan.v2.felles.nasjonalarealplanid.schema.json"
         },
         "planstatus": {
             "type": "object",


### PR DESCRIPTION
Trekker ut nasjonalarealplanid som et felles schema som blir referert til i skjema. 
Dette gjør at vi kan enklere generere modeller for skjema som refererer til nasjonalarealplanid skjema. Vi kan da la modellen nasjonalarealplanid være en ikke-generert modell da den har oneOf som skaper trøbbel ved generering. 

Endrer $id til samme navn som filnavnet på alle skjema. 

Har også fikset issue #4 i denne branchen