### PR TITLE
Forslag til kodeliste for dokumenttyper

### DIFF
--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.dokumenttyper/no.ks.fiks.plan.v2.kodelister.dokumenttyper.json
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.dokumenttyper/no.ks.fiks.plan.v2.kodelister.dokumenttyper.json
@@ -3,8 +3,80 @@
   "versjon": "v2",
   "kodeliste": [
     {
-      "kodeverdi" : "",
-      "kodebeskrivelse" : ""
+      "kodeverdi" : "PLANBESKR",
+      "kodebeskrivelse" : "Planbeskrivelse"
+    },
+    {
+      "kodeverdi" : "PLANKART",
+      "kodebeskrivelse" : "Plankart"
+    },
+    {
+      "kodeverdi" : "BLANBEST",
+      "kodebeskrivelse" : "Planbestemmelser"
+    },
+    {
+      "kodeverdi" : "PLANPROG",
+      "kodebeskrivelse" : "Planprogram"
+    },
+    {
+      "kodeverdi" : "JURILLUST",
+      "kodebeskrivelse" : "Juridisk bindende illustrasjon"
+    },
+    {
+      "kodeverdi" : "ILLUST",
+      "kodebeskrivelse" : "Illustrasjon"
+    },
+    {
+      "kodeverdi" : "KART",
+      "kodebeskrivelse" : "Kart"
+    },
+    {
+      "kodeverdi" : "VEDTAK",
+      "kodebeskrivelse" : "Vedtak"
+    },
+    {
+      "kodeverdi" : "KONSUTR",
+      "kodebeskrivelse" : "Konsekvensutredning"
+    },
+    {
+      "kodeverdi" : "KUNNGJ",
+      "kodebeskrivelse" : "Kunngjøring"
+    },
+    {
+      "kodeverdi" : "RAPPORT",
+      "kodebeskrivelse" : "Rapport"
+    },
+    {
+      "kodeverdi" : "ROS-ANALYSE",
+      "kodebeskrivelse" : "Ros-Analyse"
+    },
+    {
+      "kodeverdi" : "UTREDNING",
+      "kodebeskrivelse" : "Utredning"
+    },
+    {
+      "kodeverdi" : "INNSIGELSE",
+      "kodebeskrivelse" : "Innsigelse"
+    },
+    {
+      "kodeverdi" : "KLAGE",
+      "kodebeskrivelse" : "Klage"
+    },
+    {
+      "kodeverdi" : "SAKSFRAMLEGG",
+      "kodebeskrivelse" : "Saksframlegg"
+    },
+    {
+      "kodeverdi" : "TEGNFKL",
+      "kodebeskrivelse" : "Tegnforklaring"
+    },
+    {
+      "kodeverdi" : "GEOREFPLAN",
+      "kodebeskrivelse" : "Georeferert planklart"
+    },
+    {
+      "kodeverdi" : "KORR",
+      "kodebeskrivelse" : "Korrespondanse"
     }
   ]
 }

--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.dokumenttyper/no.ks.fiks.plan.v2.kodelister.dokumenttyper.json
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.dokumenttyper/no.ks.fiks.plan.v2.kodelister.dokumenttyper.json
@@ -3,44 +3,56 @@
   "versjon": "v2",
   "kodeliste": [
     {
-      "kodeverdi" : "PLANBESKR",
-      "kodebeskrivelse" : "Planbeskrivelse"
-    },
-    {
-      "kodeverdi" : "PLANKART",
-      "kodebeskrivelse" : "Plankart"
-    },
-    {
-      "kodeverdi" : "BLANBEST",
-      "kodebeskrivelse" : "Planbestemmelser"
-    },
-    {
-      "kodeverdi" : "PLANPROG",
-      "kodebeskrivelse" : "Planprogram"
-    },
-    {
-      "kodeverdi" : "JURILLUST",
-      "kodebeskrivelse" : "Juridisk bindende illustrasjon"
+      "kodeverdi" : "GEOREFPLAN",
+      "kodebeskrivelse" : "Georeferert planklart"
     },
     {
       "kodeverdi" : "ILLUST",
       "kodebeskrivelse" : "Illustrasjon"
     },
     {
+      "kodeverdi" : "INNSIGELSE",
+      "kodebeskrivelse" : "Innsigelse"
+    },
+    {
+      "kodeverdi" : "JURILLUST",
+      "kodebeskrivelse" : "Juridisk bindende illustrasjon"
+    },
+    {
       "kodeverdi" : "KART",
       "kodebeskrivelse" : "Kart"
     },
     {
-      "kodeverdi" : "VEDTAK",
-      "kodebeskrivelse" : "Vedtak"
+      "kodeverdi" : "KLAGE",
+      "kodebeskrivelse" : "Klage"
     },
     {
       "kodeverdi" : "KONSUTR",
       "kodebeskrivelse" : "Konsekvensutredning"
     },
     {
+      "kodeverdi" : "KORR",
+      "kodebeskrivelse" : "Korrespondanse"
+    },
+    {
       "kodeverdi" : "KUNNGJ",
       "kodebeskrivelse" : "Kunngjøring"
+    },
+    {
+      "kodeverdi" : "PLANBESKR",
+      "kodebeskrivelse" : "Planbeskrivelse"
+    },
+    {
+      "kodeverdi" : "PLANBEST",
+      "kodebeskrivelse" : "Planbestemmelser"
+    },
+    {
+      "kodeverdi" : "PLANKART",
+      "kodebeskrivelse" : "Plankart"
+    },
+    {
+      "kodeverdi" : "PLANPROG",
+      "kodebeskrivelse" : "Planprogram"
     },
     {
       "kodeverdi" : "RAPPORT",
@@ -51,18 +63,6 @@
       "kodebeskrivelse" : "Ros-Analyse"
     },
     {
-      "kodeverdi" : "UTREDNING",
-      "kodebeskrivelse" : "Utredning"
-    },
-    {
-      "kodeverdi" : "INNSIGELSE",
-      "kodebeskrivelse" : "Innsigelse"
-    },
-    {
-      "kodeverdi" : "KLAGE",
-      "kodebeskrivelse" : "Klage"
-    },
-    {
       "kodeverdi" : "SAKSFRAMLEGG",
       "kodebeskrivelse" : "Saksframlegg"
     },
@@ -71,12 +71,16 @@
       "kodebeskrivelse" : "Tegnforklaring"
     },
     {
-      "kodeverdi" : "GEOREFPLAN",
-      "kodebeskrivelse" : "Georeferert planklart"
+      "kodeverdi" : "UTREDNING",
+      "kodebeskrivelse" : "Utredning"
     },
     {
-      "kodeverdi" : "KORR",
-      "kodebeskrivelse" : "Korrespondanse"
+      "kodeverdi" : "UTTALELSE",
+      "kodebeskrivelse" : "Uttalelse"
+    },
+    {
+      "kodeverdi" : "VEDTAK",
+      "kodebeskrivelse" : "Vedtak"
     }
   ]
 }

--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.dokumenttyper/no.ks.fiks.plan.v2.kodelister.dokumenttyper.puml
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.dokumenttyper/no.ks.fiks.plan.v2.kodelister.dokumenttyper.puml
@@ -1,5 +1,88 @@
 @startjson
 {
-  Kopier inn her alt fra kodeliste json filen
+  "protokollnavn": "no.ks.fiks.plan",
+  "versjon": "v2",
+  "kodeliste": [
+    {
+      "kodeverdi" : "GEOREFPLAN",
+      "kodebeskrivelse" : "Georeferert planklart"
+    },
+    {
+      "kodeverdi" : "ILLUST",
+      "kodebeskrivelse" : "Illustrasjon"
+    },
+    {
+      "kodeverdi" : "INNSIGELSE",
+      "kodebeskrivelse" : "Innsigelse"
+    },
+    {
+      "kodeverdi" : "JURILLUST",
+      "kodebeskrivelse" : "Juridisk bindende illustrasjon"
+    },
+    {
+      "kodeverdi" : "KART",
+      "kodebeskrivelse" : "Kart"
+    },
+    {
+      "kodeverdi" : "KLAGE",
+      "kodebeskrivelse" : "Klage"
+    },
+    {
+      "kodeverdi" : "KONSUTR",
+      "kodebeskrivelse" : "Konsekvensutredning"
+    },
+    {
+      "kodeverdi" : "KORR",
+      "kodebeskrivelse" : "Korrespondanse"
+    },
+    {
+      "kodeverdi" : "KUNNGJ",
+      "kodebeskrivelse" : "Kunngjøring"
+    },
+    {
+      "kodeverdi" : "PLANBESKR",
+      "kodebeskrivelse" : "Planbeskrivelse"
+    },
+    {
+      "kodeverdi" : "PLANBEST",
+      "kodebeskrivelse" : "Planbestemmelser"
+    },
+    {
+      "kodeverdi" : "PLANKART",
+      "kodebeskrivelse" : "Plankart"
+    },
+    {
+      "kodeverdi" : "PLANPROG",
+      "kodebeskrivelse" : "Planprogram"
+    },
+    {
+      "kodeverdi" : "RAPPORT",
+      "kodebeskrivelse" : "Rapport"
+    },
+    {
+      "kodeverdi" : "ROS-ANALYSE",
+      "kodebeskrivelse" : "Ros-Analyse"
+    },
+    {
+      "kodeverdi" : "SAKSFRAMLEGG",
+      "kodebeskrivelse" : "Saksframlegg"
+    },
+    {
+      "kodeverdi" : "TEGNFKL",
+      "kodebeskrivelse" : "Tegnforklaring"
+    },
+    {
+      "kodeverdi" : "UTREDNING",
+      "kodebeskrivelse" : "Utredning"
+    },
+    {
+      "kodeverdi" : "UTTALELSE",
+      "kodebeskrivelse" : "Uttalelse"
+    },
+    {
+      "kodeverdi" : "VEDTAK",
+      "kodebeskrivelse" : "Vedtak"
+    }
+  ]
 }
 @endjson


### PR DESCRIPTION
Forslag til kodeliste for dokumenttyper.
Kom med kommentarer og så får vi diskutert denne mer på neste møte.

Dette er basert på denne kilden: https://www.ks.no/fagomrader/digitalisering/felleslosninger/verktoykasse-plan--og-byggesak/verktoy/sammenhengende-tjenester---integrasjoner/arkivlett/

Her er også et forslag til dokumentasjon i Wiki som kan forklare litt mer om kodelisten, som f.eks. kilde og utvidet beskrivelse (kom gjerne med bedre beskrivelser der det er nødvendig).

https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Dokumenttyper
