### PR TITLE
Forslag til kodeliste for lovreferanser

### DIFF
--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.lovreferanser/no.ks.fiks.plan.v2.kodelister.lovreferanser.json
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.lovreferanser/no.ks.fiks.plan.v2.kodelister.lovreferanser.json
@@ -1,10 +1,31 @@
 {
   "protokollnavn": "no.ks.fiks.plan",
+  "navn": "lovreferanser",
   "versjon": "v2",
   "kodeliste": [
     {
-      "kodeverdi" : "",
-      "kodebeskrivelse" : ""
+      "kodeverdi" : "1",
+      "kodebeskrivelse" : "Før BL 1924"
+    },
+    {
+      "kodeverdi" : "2",
+      "kodebeskrivelse" : "BL 1924"
+    },
+    {
+      "kodeverdi" : "3",
+      "kodebeskrivelse" : "BL 1965"
+    },
+    {
+      "kodeverdi" : "4",
+      "kodebeskrivelse" : "PBL 1985"
+    },
+    {
+      "kodeverdi" : "5",
+      "kodebeskrivelse" : "PBL 1985 eller før"
+    },
+    {
+      "kodeverdi" : "6",
+      "kodebeskrivelse" : "PBL 2008"
     }
   ]
 }


### PR DESCRIPTION
Forslag til kodeliste for lovreferanser

Kilde: https://sosi.arkitektum.no/Objekttype/Index/EAID_2D6968A7_74CB_4728_B216_3115340DB722

Er `lovreferanser` ok navn på denne kodelisten eller burde den hete `LovreferanseTyper` som i kilden?

Her er også et forslag til dokumentasjon i Wiki som kan forklare litt mer om kodelisten, som f.eks. kilde og utvidet beskrivelse der det er nødvendig.

https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Lovreferanser