### PR TITLE
Forslag til kodeliste for planstatuser

### DIFF
--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.planstatuser/no.ks.fiks.plan.v2.kodelister.planstatuser.json
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.planstatuser/no.ks.fiks.plan.v2.kodelister.planstatuser.json
@@ -1,10 +1,47 @@
 {
   "protokollnavn": "no.ks.fiks.plan",
+  "navn": "planstatuser",
   "versjon": "v2",
   "kodeliste": [
     {
-      "kodeverdi" : "",
-      "kodebeskrivelse" : ""
+      "kodeverdi" : "0",
+      "kodebeskrivelse" : "Planinitiativ"
+    },
+    {
+      "kodeverdi" : "1",
+      "kodebeskrivelse" : "Planlegging igangsatt"
+    },
+    {
+      "kodeverdi" : "2",
+      "kodebeskrivelse" : "Planforslag"
+    },
+    {
+      "kodeverdi" : "3",
+      "kodebeskrivelse" : "Endelig vedtatt arealplan\"
+    },
+    {
+      "kodeverdi" : "4",
+      "kodebeskrivelse" : "Opphevet"
+    },
+    {
+      "kodeverdi" : "5",
+      "kodebeskrivelse" : "Utgått/erstattet"
+    },
+    {
+      "kodeverdi" : "6",
+      "kodebeskrivelse" : "Vedtatt plan med utsatt rettsvirkning"
+    },
+    {
+      "kodeverdi" : "8",
+      "kodebeskrivelse" : "Overstyrt"
+    },
+    {
+      "kodeverdi" : "9",
+      "kodebeskrivelse" : "Avvist"
+    },
+    {
+      "kodeverdi" : "10",
+      "kodebeskrivelse" : "Trukket/uaktuelt"
     }
   ]
 }


### PR DESCRIPTION
Forslag til kodeliste for planstatuser

Kilde: https://sosi.geonorge.no/standarder/Plan/5.0/#_applicationschema_plan_5_0

Her er også et forslag til dokumentasjon i Wiki som kan forklare litt mer om kodelisten, som f.eks. kilde og utvidet beskrivelse der det er nødvendig.

https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Planstatuser