### PR TITLE
Forslag til kodeliste for plantyper

### DIFF
--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.plantyper/no.ks.fiks.plan.v2.kodelister.plantyper.json
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.plantyper/no.ks.fiks.plan.v2.kodelister.plantyper.json
@@ -1,10 +1,39 @@
 {
   "protokollnavn": "no.ks.fiks.plan",
+  "navn": "plantyper",
   "versjon": "v2",
   "kodeliste": [
     {
-      "kodeverdi" : "",
-      "kodebeskrivelse" : ""
+      "kodeverdi" : "10",
+      "kodebeskrivelse" : "Fylkesplanens arealdel"
+    },
+    {
+      "kodeverdi" : "11",
+      "kodebeskrivelse" : "Fylkesdelplan"
+    },
+    {
+      "kodeverdi" : "20",
+      "kodebeskrivelse" : "Kommuneplanens arealdel"
+    },
+    {
+      "kodeverdi" : "21",
+      "kodebeskrivelse" : "Kommunedelplan"
+    },
+    {
+      "kodeverdi" : "30",
+      "kodebeskrivelse" : "Reguleringsplan"
+    },
+    {
+      "kodeverdi" : "31",
+      "kodebeskrivelse" : "Mindre vesentlig reguleringsendring"
+    },
+    {
+      "kodeverdi" : "32",
+      "kodebeskrivelse" : "Bebyggelsesplan ihht. Reguleringsplan"
+    },
+    {
+      "kodeverdi" : "33",
+      "kodebeskrivelse" : "Bebyggelsesplan ihht kommunepl. arealdel"
     }
   ]
 }


### PR DESCRIPTION
Forslag til kodeliste for plantyper

Kilder: 
- https://sosi.geonorge.no/standarder/Plan/5.0/#_applicationschema_plan_5_0  
- https://sosi.arkitektum.no/Objekttype/Index/EAID_1B9263B7_B6EC_4feb_A9DA_D307C40E5CD8?name=FpPlantype&hasSOSItag=False&hasEngtag=False&hasNVDBtag=False
- https://sosi.arkitektum.no/Objekttype/Index/EAID_FFA4D7C6_248C_4f9c_BC1B_DEA73A3E5B02?name=RbPlantype&hasSOSItag=False&hasEngtag=False&hasNVDBtag=False
- https://sosi.arkitektum.no/Objekttype/Index/EAID_159D4410_D06C_412b_B575_7DB957A043A8?name=KpPlantype&hasSOSItag=False&hasEngtag=False&hasNVDBtag=False

Jeg slo sammen typene jeg fant i FpPlantype, RbPlantype og KpPlantype. Det kan godt være det er feil? Kom med kommentar.

Her er også et forslag til dokumentasjon i Wiki som kan forklare litt mer om kodelisten, som f.eks. kilde og utvidet beskrivelse der det er nødvendig.

https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Plantyper