### PR TITLE
Forslag til kodeliste for vertikalnivaa

### DIFF
--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.vertikalnivaa/no.ks.fiks.plan.v2.kodelister.vertikalnivaa.json
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.vertikalnivaa/no.ks.fiks.plan.v2.kodelister.vertikalnivaa.json
@@ -1,10 +1,27 @@
 {
   "protokollnavn": "no.ks.fiks.plan",
+  "navn": "vertikalnivaa",
   "versjon": "v2",
   "kodeliste": [
     {
-      "kodeverdi" : "",
-      "kodebeskrivelse" : ""
+      "kodeverdi" : "1",
+      "kodebeskrivelse" : "Under grunnen (tunnel)"
+    },
+    {
+      "kodeverdi" : "2",
+      "kodebeskrivelse" : "På grunnen/vannoverflate"
+    },
+    {
+      "kodeverdi" : "3",
+      "kodebeskrivelse" : "Over grunnen (bru)"
+    },
+    {
+      "kodeverdi" : "4",
+      "kodebeskrivelse" : "På bunnen (vann/sjø)"
+    },
+    {
+      "kodeverdi" : "5",
+      "kodebeskrivelse" : "I vannsøylen"
     }
   ]
 }


### PR DESCRIPTION
Forslag til kodeliste for vertikalnivaa

Kilde: https://sosi.geonorge.no/standarder/Plan/5.0/#_applicationschema_plan_5_0

Her er også et forslag til dokumentasjon i Wiki som kan forklare litt mer om kodelisten, som f.eks. kilde og utvidet beskrivelse der det er nødvendig.

https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Vertikalnivaa