### PR TITLE
Forslag til kodeliste for forslagsstillertyper

### DIFF
--- a/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.forslagsstillertyper/no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json
+++ b/Schema/V2/kodelister/no.ks.fiks.plan.v2.kodelister.forslagsstillertyper/no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json
@@ -4,8 +4,12 @@
   "versjon": "v2",
   "kodeliste": [
     {
-      "kodeverdi" : "",
-      "kodebeskrivelse" : ""
+      "kodeverdi" : "1",
+      "kodebeskrivelse" : "offentlig"
+    },
+    {
+      "kodeverdi" : "2",
+      "kodebeskrivelse" : "privat"
     }
   ]
 }

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json
@@ -65,11 +65,16 @@
             }
         },
         "forslagstillerType": {
-            "type": "string",
-            "enum": [
-                "offentlig",
-                "privat"
-            ]
+            "type": "object",
+            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json",
+            "properties": {
+                "kodeverdi": {
+                    "type": "string"
+                },
+                "kodebeskrivelse": {
+                    "type": "string"
+                }
+            }
         },
         "alternativFinnes": {
             "type": "boolean"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
@@ -52,11 +52,16 @@
             "$ref": "no.ks.fiks.plan.v2.felles.saksnummer.schema.json"
         },
         "forslagstillerType": {
-            "type": "string",
-            "enum": [
-                "offentlig",
-                "privat"
-            ]
+            "type": "object",
+            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json",
+            "properties": {
+                "kodeverdi": {
+                    "type": "string"
+                },
+                "kodebeskrivelse": {
+                    "type": "string"
+                }
+            }
         },
         "vedlegg": {
             "type": "array",

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.opprett.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.opprett.schema.json
@@ -48,11 +48,16 @@
             "$ref": "no.ks.fiks.plan.v2.felles.saksnummer.schema.json"
         },
         "forslagsstillerType": {
-            "type": "string",
-            "enum": [
-                "offentlig",
-                "privat"
-            ]
+            "type": "object",
+            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json",
+            "properties": {
+                "kodeverdi": {
+                    "type": "string"
+                },
+                "kodebeskrivelse": {
+                    "type": "string"
+                }
+            }
         }
     },
     "required": [


### PR DESCRIPTION
Forslag til kodeliste for forslagsstillertyper

Kilde: https://sosi.geonorge.no/standarder/Plan/5.0/#forslagsstillertype

Her er også et forslag til dokumentasjon i Wiki som kan forklare litt mer om kodelisten, som f.eks. kilde og utvidet beskrivelse der det er nødvendig.

https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Forslagsstillertyper

