### PR TITLE
Fikset feil i resultat-skjema for finn midlertidige forbud mot tiltak

### DIFF
--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigeforbudmottiltak.finn.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.midlertidigeforbudmottiltak.finn.resultat.schema.json
@@ -8,9 +8,7 @@
         "midlertidigeForbud": {
             "type": "array",
             "items": {
-                "midlertidigForbud": {
-                    "$ref": "no.ks.fiks.plan.v2.felles.midlertidigforbud.schema.json"
-                }
+                "$ref": "no.ks.fiks.plan.v2.felles.midlertidigforbud.schema.json"
             }
         }
     }


### PR DESCRIPTION
I arbeidet med å lage kodeeksempler basert på generert C# kode oppdaget jeg at i dette skjemaet ville ikke den genererte koden bli helt korrekt. Listen med midlertidige forbud bør bare peke direkte til felles skjema og datatypen.
Slik som for dette skjemaet: [no.ks.fiks.plan.v2.innsyn.dispensasjoner.finn.resultat](https://github.com/ks-no/fiks-plan-specification/blob/main/Schema/V2/no.ks.fiks.plan.v2.innsyn.dispensasjoner.finn.resultat.schema.json)

