### PR TITLE
Lagt på id i dokument objektet og endret til id for å hente dokumentfil

### DIFF
--- a/Schema/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json
@@ -81,6 +81,6 @@
         }
     },
     "required": [
-        "plannavn",
+        "plannavn"
     ]
 }

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json
@@ -6,7 +6,7 @@
     "type": "object",
     "properties": {
         "id": {
-            "description": "En unik id innenfor planregister som kan benyttes for unik identifisering av et dokument objekt og f.eks. henting av dokument fil fra planregister. Påkrevd å returneres fra planregister når man henter dokument objekt via tjenester. Ikke gyldig når man registrerer et dokument objekt inn i planregister.",
+            "description": "En unik id innenfor planregister som kan benyttes for unik identifisering av et dokumentobjekt og f.eks. henting av dokumentfil fra planregister. Påkrevd å returneres fra planregister når man henter dokumentobjekt via tjenester. Ikke gyldig når man registrerer et dokumentobjekt inn i planregister.",
             "type": "string"
         },
         "tittel": {

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json
@@ -5,6 +5,10 @@
     "definitions": {},
     "type": "object",
     "properties": {
+        "id": {
+            "description": "En unik id innenfor planregister som kan benyttes for unik identifisering av et dokument objekt og f.eks. henting av dokument fil fra planregister. Påkrevd å returneres fra planregister når man henter dokument objekt via tjenester. Ikke gyldig når man registrerer et dokument objekt inn i planregister.",
+            "type": "string"
+        },
         "tittel": {
             "type": "string"
         },

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.dokumentfil.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.dokumentfil.hent.schema.json
@@ -1,16 +1,17 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "no.ks.fiks.plan.v2.innsyn.dokumentfil.hent.schema.json",
-    "description": "Henter en fil basert på referanseDokumentfil. Resultatet vil være en fil.",
+    "description": "Henter en fil basert på id, som er den unike id som hver fil har innenfor et planregister. Resultatet vil være en fil.",
     "title": "HentDokumentfil",
     "definitions": {},
     "type": "object",
     "properties": {
-        "referanseDokumentfil": {
+        "id": {
+            "description": "Den unike id som benyttes for unik identifisering av et dokument objekt.",
             "type": "string"
         }
     },
     "required": [
-        "referanseDokumentfil"
+        "id"
     ]
 }

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.dokumentfil.hent.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.dokumentfil.hent.schema.json
@@ -1,13 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "$id": "no.ks.fiks.plan.v2.innsyn.dokumentfil.hent.schema.json",
-    "description": "Henter en fil basert på id, som er den unike id som hver fil har innenfor et planregister. Resultatet vil være en fil.",
+    "description": "Henter en dokumentfil basert på id, som er den unike id som hver dokumentfil har innenfor et planregister. Resultatet vil være en fil.",
     "title": "HentDokumentfil",
     "definitions": {},
     "type": "object",
     "properties": {
         "id": {
-            "description": "Den unike id som benyttes for unik identifisering av et dokument objekt.",
+            "description": "Den unike id-en som benyttes for unik identifisering av et dokumentobjekt.",
             "type": "string"
         }
     },


### PR DESCRIPTION
Ref issue #105 
Nå har dokument objektet en id som skal være unik i planregister.
Denne id'en kan benyttes da for å hente en dokument fil.
**Spørsmål:**
Skal man ignorere eventuell id som kommer inn når man registrerer et dokument objekt eller gir en ugyldig forespørsel tilbake? 