### PR TITLE
Endret til å peke til Wiki

### DIFF
--- a/Schema/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.arealplan.schema.json
@@ -10,7 +10,7 @@
         },
         "plantype": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.plantyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Plantyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -25,7 +25,7 @@
         },
         "planstatus": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.planstatuser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Planstatuser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -54,7 +54,7 @@
         },
         "lovreferanse": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.lovreferanser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Lovreferanser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -66,7 +66,7 @@
         },
         "forslagstillerType": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Forslagsstillertyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.dispensasjon.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.dispensasjon.schema.json
@@ -10,7 +10,7 @@
         },
         "dispensasjonType": {
             "type": "object",
-            "description" : "Kodeliste: no.ks.fiks.plan.v2.kodelister.plandispensasjonstyper.json",
+            "description" : "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Dispensasjonstyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -22,7 +22,7 @@
         },
         "dispensasjonFra": {
             "type": "object",
-            "description" : "Kodeliste: no.ks.fiks.plan.v2.kodelister.dispensasjonstyper.json",
+            "description" : "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Dispensasjonstyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -47,7 +47,7 @@
         },
         "vertikalnivaa": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.vertikalnivaa.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Vertikalnivaa",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.dokument.schema.json
@@ -18,7 +18,7 @@
         },
         "dokumenttype": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.dokumenttyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Dokumenttyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.flate.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.flate.schema.json
@@ -24,7 +24,7 @@
         },
         "koordinatsystem": {
             "type": "object",
-            "description" : "Kodeliste: no.ks.fiks.plan.v2.kodelister.koordinatsystem.json",
+            "description" : "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Koordinatsystemer",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.midlertidigforbud.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.midlertidigforbud.schema.json
@@ -17,7 +17,7 @@
         },
         "pblTiltakForbudtype": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.forbudtyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Pbltiltakforbudtyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.planbehandling.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.planbehandling.schema.json
@@ -17,7 +17,7 @@
         },
         "planbehandlingtype": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.behandlingstyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Behandlingstyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.felles.posisjon.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.posisjon.schema.json
@@ -20,7 +20,7 @@
         },
         "koordinatsystem": {
             "type": "object",
-            "description" : "Kodeliste: no.ks.fiks.plan.v2.kodelister.koordinatsystem.json",
+            "description" : "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Koordinatsystemer",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.innsyn.relaterteplaner.hent.resultat.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.innsyn.relaterteplaner.hent.resultat.schema.json
@@ -14,7 +14,7 @@
           "properties": {
             "planforhold": {
               "type": "object",
-              "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.planforhold.json",
+              "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-PlanforholdTyper",
               "properties": {
                 "kodeverdi": {
                   "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.oppdater.schema.json
@@ -11,7 +11,7 @@
         },
         "plantype": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.plantyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Plantyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -26,7 +26,7 @@
         },
         "planstatus": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.planstatuser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Planstatuser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -52,7 +52,7 @@
         },
         "lovreferanse": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.lovreferanser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Lovreferanser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -67,7 +67,7 @@
         },
         "forslagstillerType": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Forslagsstillertyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.opprett.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.arealplan.opprett.schema.json
@@ -7,7 +7,7 @@
     "properties": {
         "plantype": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.plantyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Plantyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -22,7 +22,7 @@
         },
         "planstatus": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.planstatuser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Planstatuser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -48,7 +48,7 @@
         },
         "lovreferanse": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.lovreferanser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Lovreferanser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -63,7 +63,7 @@
         },
         "forslagsstillerType": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.forslagsstillertyper.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Forslagsstillertyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planbehandling.registrer.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planbehandling.registrer.schema.json
@@ -11,7 +11,7 @@
         },
         "planstatus": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.planstatuser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Planstatuser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"

--- a/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planendring.registrer.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.oppdatering.planendring.registrer.schema.json
@@ -21,7 +21,7 @@
         },
         "behandlingstype": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.behandlingstype.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Behandlingstyper",
             "properties": {
                 "kodeverdi": {
                     "type": "string"
@@ -36,7 +36,7 @@
         },
         "lovreferanse": {
             "type": "object",
-            "description": "Kodeliste: no.ks.fiks.plan.v2.kodelister.lovreferanser.json",
+            "description": "Kodeliste: https://github.com/ks-no/fiks-plan-specification/wiki/Kodeliste-Lovreferanser",
             "properties": {
                 "kodeverdi": {
                     "type": "string"


### PR DESCRIPTION
Ref issue #115 har vi endret til å peke til Wiki i skjema.
I Wiki kan vi peke til Geonorge sider hvor det finnes definert der.
For andre hvor vi ikke har noe i Geonorge enda så kan vi vise hvordan vi ønsker at det skal se ut.
I Wiki kan vi også vise til pull-requests og issues hvor vi har diskutert hvorfor vi har kommet dit.