### PR TITLE
Fikset feil i required for dispensasjontype i dispensasjon

### DIFF
--- a/Schema/V2/no.ks.fiks.plan.v2.felles.dispensasjon.schema.json
+++ b/Schema/V2/no.ks.fiks.plan.v2.felles.dispensasjon.schema.json
@@ -88,7 +88,7 @@
         }
     },
     "required": [
-        "dispensasjonType",
+        "dispensasjontype",
         "nasjonalArealplanId",
         "vedtaksdato",
         "innvilgetDispensasjon",


### PR DESCRIPTION
Forskjell i navn på felt og i required for `dispensasjontype`.

Ref feil rapportert i Slack:

> Jeg får lastet skjemaet for RegistrerDispensasjon nå og får kjørt skjemavalideringen. Men det er en feil i skjemaet: Feltet "dispensasjonType" fra 0.9.10 har skiftet navn til "dispensasjontype" i skjemaet (øverste røde bokseni utklippet under), men i "required" (lista over obligatoriske felter) står det fremdeles "dispensasjonType" (nederste røde boksen i utklippet under). Dermed får jeg alltid valideringsfeil.